### PR TITLE
feat: Add articles page and update bio/employment info

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,3 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 echo "🔍 Running pre-commit checks..."
 
 # Run lint-staged for staged files

--- a/content/data.json
+++ b/content/data.json
@@ -6,8 +6,8 @@
     "location": "Golden Valley, MN"
   },
   "bio": {
-    "short": "Founding architect of Sitecore XM Cloud - building enterprise-grade software that scales. Leading CMS development in the Age of AI.",
-    "full": "I'm the founding architect of Sitecore XM Cloud, where with the help of an army of Jedi masters, I had the privilege of designing and building the system from concept to global SaaS launch. I've been building software since I was 8 years old, when I taught myself to code by reading PC magazines my mom brought home from work. That early start gave me a deep understanding of how software systems evolve and what it takes to build things that truly last.\n\nXM Cloud was truly a team effort. Nick Wesselman was the founding Product Manager who conceived the vision and provided the initial push to get the project off the ground, with Dave O'Flanagan and Roger Connolly sponsoring and championing the initiative. I led the architectural design, proof of concept, implementation, and production launch. When Nick moved on, Justin Vogt stepped in as Product Manager and did phenomenal work maintaining momentum and owning the vision. Along the way, I learned immensely from brilliant developers and architects, most notably Alistair Deneys and Charlie Turano, whose insights shaped both the technical approach and my own growth as an architect. After launch, I focused on optimization and redesign, cutting costs significantly while re-architecting tenancy and infrastructure to save millions. I also drove the cultural shift to continuous delivery, fundamentally changing how we ship software and scale our systems.\n\nMy specialty is building enterprise-grade software that scales - specifically the content management systems themselves: the engines, APIs, and infrastructure that enable content management at enterprise scale. From those early programming days to building applicant tracking systems, time management tools, and eventually enterprise CMS solutions, I've consistently built the robust, scalable foundations that others build upon.\n\nAt Altudo, I'm working on the future of CMS in the Age of AI - developing agentic workflows and AI-driven experiences that transform how content management works. I'm not just adding AI features; I'm reimagining how these systems can use AI to speed up implementation, improve authoring experiences, and deliver intelligent content orchestration.\n\nThroughout my career, I've specialized in architecture and product development across consulting and product companies - from building internal tools at TempWorks and ILM to designing enterprise solutions at Horizontal Integration, Perficient, and Avanade, before leading development at Sitecore.\n\nMy approach combines decades of hands-on development with engineering expertise, AI innovation, and product strategy. Having grown up alongside the evolution of software development, I understand both the fundamentals and the cutting edge. I focus on building systems that scale to serve millions while enabling developers and content creators to achieve more. I thrive at the intersection of engineering and AI - designing next-generation CMS systems, building great developer experiences, and defining how content management evolves in an AI-driven world.\n\nWhether it's enterprise systems serving millions of users or innovative AI workflows that transform content operations, I believe in building solid foundations that last and enable others to create extraordinary digital experiences."
+    "short": "Founding architect of Sitecore XM Cloud - building enterprise-grade software that scales. Focused on where AI, products, platforms, and experience come together to redefine what's possible.",
+    "full": "I'm the founding architect of Sitecore XM Cloud, where I designed and built the system from concept to global SaaS launch. I've been building software since I was 8 years old, when I taught myself to code by reading PC magazines my mom brought home from work. That early start gave me a deep understanding of how software systems evolve and what it takes to build things that truly last.\n\nXM Cloud was truly a team effort. Nick Wesselman was the founding Product Manager who conceived the vision and provided the initial push to get the project off the ground, with Dave O'Flanagan and Roger Connolly sponsoring and championing the initiative. I led the architectural design, proof of concept, implementation, and production launch. When Nick moved on, Justin Vogt stepped in as Product Manager and did phenomenal work maintaining momentum and owning the vision. Along the way, I learned immensely from brilliant developers and architects, most notably Alistair Deneys and Charlie Turano, whose insights shaped both the technical approach and my own growth as an architect. After launch, I focused on optimization and redesign, cutting costs significantly while re-architecting tenancy and infrastructure to save millions. I also drove the cultural shift to continuous delivery, fundamentally changing how we ship software and scale our systems.\n\nMy specialty is building enterprise-grade software that scales - specifically the content management systems themselves: the engines, APIs, and infrastructure that enable content management at enterprise scale. From those early programming days to building applicant tracking systems, time management tools, and eventually enterprise CMS solutions, I've consistently built the robust, scalable foundations that others build upon.\n\nMost recently at Altudo, I worked on building momentum in the DXP space, from FastLane for XM Cloud to workflows that helped teams move faster and with more intent. I'm proud of what we made possible.\n\nNow I'm focused on what comes next... where AI, products and platforms, and experience come together to redefine what's possible in how we build, connect, and create online. The next generation won't just manage content or launch campaigns. It will anticipate, adapt, and transform how organizations work and how they serve people.\n\nThroughout my career, I've specialized in architecture and product development across consulting and product companies - from building internal tools at TempWorks and ILM to designing enterprise solutions at Horizontal Integration, Perficient, and Avanade, before leading development at Sitecore.\n\nMy approach combines decades of hands-on development with engineering expertise, AI innovation, and product strategy. Having grown up alongside the evolution of software development, I understand both the fundamentals and the cutting edge. I focus on building systems that scale to serve millions while enabling developers and content creators to achieve more. I thrive at the intersection of engineering and AI - designing next-generation systems, building great developer experiences, and defining how digital experiences evolve in an AI-driven world.\n\nWhether it's enterprise systems serving millions of users or innovative AI workflows that transform operations, I believe in building solid foundations that last and enable others to create extraordinary digital experiences. AI isn't just a hash tag for me. It brings about so much opportunity when used with intent. Building products isn't what I do... it's who I am. I happen to have a bit of free time, so reach out!"
   },
   "professional": {
     "keywords": [
@@ -60,14 +60,14 @@
     {
       "title": "Vice President | Chief Architect",
       "company": "Altudo",
-      "period": "Sep 2024 - Present",
+      "period": "Sep 2024 - Oct 2025",
       "highlights": [
-        "Leading CMS architecture strategies for the Age of AI",
-        "Pioneering agentic AI workflows that transform content management systems",
-        "Designing next-generation digital experience systems with AI integration",
-        "Defining the future of content management through AI-driven innovation"
+        "Built momentum in the DXP space with FastLane for XM Cloud",
+        "Developed workflows that helped teams move faster and with more intent",
+        "Pioneered agentic AI workflows that transform content management systems",
+        "Advanced next-generation digital experience systems with AI integration"
       ],
-      "description": "Leading the evolution of content management systems in the Age of AI. Pioneering agentic workflows and intelligent architectures that fundamentally transform how CMS systems operate, scale, and deliver value to enterprise clients."
+      "description": "Led the evolution of content management systems in the Age of AI. Built momentum in the DXP space, from FastLane for XM Cloud to workflows that helped teams move faster and with more intent."
     },
     {
       "title": "Senior Director, Engineering – XM Cloud",
@@ -193,6 +193,178 @@
       ]
     }
   ],
+  "thoughtLeadership": [
+    {
+      "title": "The Next Great DXP Will Sell Transformation, Not Software",
+      "url": "https://cmscritic.com/the-next-great-dxp-will-sell-transformation-not-software",
+      "platform": "CMS Critic",
+      "type": "article",
+      "date": "October 1, 2025",
+      "summary": "Feature wars are a dead end. The next wave of DXPs will win by changing how teams ship, learn, and govern. This article shows how to anchor platform strategy to measurable business transformation and cultural adoption, not just tools.",
+      "highlights": [
+        "Defines a value chain for DXP that ties product, engineering, and change management",
+        "Illustrates a transformation roadmap with operating model shifts, not just feature rollouts",
+        "Outlines leadership metrics that prove impact across speed, quality, and margin"
+      ],
+      "topics": [
+        "DXP",
+        "Product Strategy",
+        "Org Change",
+        "Operating Model",
+        "SaaS"
+      ]
+    },
+    {
+      "title": "Lipstick on a Pig: Why Most Agents Aren't",
+      "url": "https://www.linkedin.com/pulse/lipstick-pig-why-most-agents-arent-andy-cohen-grotc/",
+      "platform": "LinkedIn",
+      "type": "article",
+      "date": "September 20, 2025",
+      "summary": "Many so called agents are thin scripts wearing AI makeup. Real agents reason, plan, and coordinate tools across changing contexts. This piece offers a litmus test for agentic credibility and explains why orchestration matters more than wrappers.",
+      "highlights": [
+        "Agent credibility checklist across autonomy, memory, tool use, and recovery",
+        "Patterns for safe delegation and guardrails in production environments",
+        "How to separate marketing claims from operational reality"
+      ],
+      "topics": ["AI Agents", "Orchestration", "Safety", "Production Readiness"]
+    },
+    {
+      "title": "Commits Don't Lie: XM Cloud's Future in Plain Sight",
+      "url": "https://www.linkedin.com/pulse/commits-dont-lie-xm-clouds-future-plain-sight-andy-cohen-qgnsc/",
+      "platform": "LinkedIn",
+      "type": "article",
+      "date": "September 19, 2025",
+      "summary": "Roadmaps whisper. Repos shout. By reading dependency shifts, module seams, and deployment scripts, you can forecast where a platform is headed. This article decodes XM Cloud commit signals to surface strategy early.",
+      "highlights": [
+        "Commit signal taxonomy across naming, dependencies, and platform seams",
+        "How to distinguish refactor noise from roadmap intent",
+        "Practical tips for investors, partners, and customers reading public repos"
+      ],
+      "topics": [
+        "SaaS Architecture",
+        "Engineering Signals",
+        "Roadmap Intelligence"
+      ]
+    },
+    {
+      "title": "Twelve Lessons I'm Still Learning: A Letter to My Younger Self",
+      "url": "https://www.linkedin.com/pulse/twelve-lessons-im-still-learning-letter-my-younger-self-andy-cohen-oh5sc/",
+      "platform": "LinkedIn",
+      "type": "article",
+      "date": "September 14, 2025",
+      "summary": "Leadership is a practice, not a promotion. These twelve lessons cover clarity under pressure, bias for delivery, and the discipline of kind feedback. It is a pocket guide for staying human while building hard things.",
+      "highlights": [
+        "Trade careful for clear when stakes are rising",
+        "Build systems that make the right thing easy",
+        "Coach in verbs and numbers, not vibes"
+      ],
+      "topics": ["Leadership", "Career", "Execution", "Culture"]
+    },
+    {
+      "title": "The Future of Architects and Product Managers in the Age of AI",
+      "url": "https://www.linkedin.com/pulse/future-architects-product-managers-age-ai-andy-cohen-qawsc/",
+      "platform": "LinkedIn",
+      "type": "article",
+      "date": "September 5, 2025",
+      "summary": "Architecture is shifting from diagram stewardship to outcome ownership. As AI automates scaffolding, the winning architects act like product managers who shape bets, measure impact, and tune loops.",
+      "highlights": [
+        "Outcome first design with experiment cadence and product telemetry",
+        "From reference diagrams to performance contracts and SLOs",
+        "Skills map for the architect to PM evolution"
+      ],
+      "topics": ["Architecture", "Product Management", "AI", "SLOs"]
+    },
+    {
+      "title": "Agent-to-Agent Personalization: Trust, First Impressions, and the Grudge Factor",
+      "url": "https://cmscritic.com/agent-to-agent-personalization-trust-first-impressions-and-the-grudge-factor",
+      "platform": "CMS Critic",
+      "type": "article",
+      "date": "September 5, 2025",
+      "summary": "Agents will increasingly serve other agents. Personalization must account for machine to machine trust, first contact rituals, and long memory. This article proposes patterns that reduce nondeterminism and build cooperative behavior.",
+      "highlights": [
+        "First impression protocols for agent handshakes",
+        "Managing memory, reputation, and forgiveness across agents",
+        "Designing for graceful failure and negotiated retries"
+      ],
+      "topics": ["Personalization", "AI Agents", "Trust", "Governance"]
+    },
+    {
+      "title": "Building to Standards That Don't Exist Yet",
+      "url": "https://www.linkedin.com/pulse/building-standards-dont-exist-yet-andy-cohen-1hgyc/",
+      "platform": "LinkedIn",
+      "type": "article",
+      "date": "August 26, 2025",
+      "summary": "On the frontier there are no recipes. This article lays out how to build responsibly when patterns are immature, including how to design seams, isolate risk, and write standards that can survive version two.",
+      "highlights": [
+        "Seam first architecture with well lit escape hatches",
+        "Risk isolation by domain, not by team",
+        "Drafting living standards that converge with use"
+      ],
+      "topics": ["Standards", "Architecture", "Governance", "Experimentation"]
+    },
+    {
+      "title": "The CMS is Dead. Long Live Structured Vibing.",
+      "url": "https://www.linkedin.com/pulse/cms-dead-long-live-structured-vibing-andy-cohen-ashpc/",
+      "platform": "LinkedIn",
+      "type": "article",
+      "date": "August 20, 2025",
+      "summary": "Rigid content models cannot keep up with adaptive experiences. Structured vibing pairs typed content with generative flexibility so teams can keep control while the system improvises within safe bounds.",
+      "highlights": [
+        "Explains structure plus improvisation as a governance model",
+        "Shows how tokens and policies set creative lanes for AI",
+        "Maps use cases from content ops to on site orchestration"
+      ],
+      "topics": ["CMS", "AI Content", "Design Tokens", "Governance"]
+    },
+    {
+      "title": "Forget DevEx, The Future is AgEx",
+      "url": "https://www.linkedin.com/pulse/forget-devex-future-agex-andy-cohen-ms8hc/",
+      "platform": "LinkedIn",
+      "type": "article",
+      "date": "August 20, 2025",
+      "summary": "Developers are no longer the only first class users of platforms. Agents are. AgEx focuses on giving agents clear tools, contracts, and feedback loops so they can work with us and for us at scale.",
+      "highlights": [
+        "Designing APIs and events for agent consumption",
+        "Operational contracts for agent behavior and cost control",
+        "Metrics that track agent productivity and safety"
+      ],
+      "topics": ["DevEx", "AgEx", "APIs", "Observability", "Cost"]
+    },
+    {
+      "title": "Accelerators Done Right: From Sales Demos to Real Delivery",
+      "url": "https://www.linkedin.com/pulse/accelerators-done-right-from-sales-demos-real-delivery-andy-cohen-brxfc/",
+      "platform": "LinkedIn",
+      "type": "article",
+      "date": "August 20, 2025",
+      "summary": "Most accelerators stop at the sizzle. This article details how to build accelerators that compress delivery time in production through reusable components, automation, and ops ready defaults.",
+      "highlights": [
+        "Separates demo kits from delivery accelerators with entry and exit criteria",
+        "Defines reusable backbone assets across components, scaffolding, and CI",
+        "Links accelerator value to margin, quality, and ramp time"
+      ],
+      "topics": ["Accelerators", "Delivery", "SaaS", "Reuse", "CI/CD"]
+    },
+    {
+      "title": "Three Lessons from Building and Scaling XM Cloud",
+      "url": "https://www.linkedin.com/pulse/three-lessons-from-building-scaling-xm-cloud-andy-cohen-fjjqc/",
+      "platform": "LinkedIn",
+      "type": "article",
+      "date": "August 19, 2025",
+      "summary": "Behind the scenes of launching and scaling XM Cloud. Three lessons on aligning architecture with unit economics, turning continuous delivery into culture, and designing for cost aware growth.",
+      "highlights": [
+        "Architecture choices tied directly to margin and tenancy economics",
+        "Culture of continuous delivery as an operating system for teams",
+        "Pragmatic patterns for scale without runaway complexity"
+      ],
+      "topics": [
+        "SaaS",
+        "XM Cloud",
+        "Cost Optimization",
+        "Continuous Delivery",
+        "Tenancy"
+      ]
+    }
+  ],
   "community": {
     "mvpStatus": "Sitecore MVP",
     "mvpAwards": [
@@ -241,11 +413,7 @@
         "location": "Antwerp, Belgium",
         "date": "April 2025",
         "sessionTitle": "Full Circle: The Architect of XM Cloud builds an XM Cloud Site (as a partner for the first time)",
-        "topics": [
-          "XM Cloud",
-          "Architecture",
-          "Partner Implementation"
-        ],
+        "topics": ["XM Cloud", "Architecture", "Partner Implementation"],
         "description": "A unique perspective presentation where the founding architect of XM Cloud demonstrates building an XM Cloud site as a partner implementation, offering insights into both the platform creation and practical implementation challenges.",
         "sessionizeUrl": "https://sessionize.com/iamandycohen"
       },
@@ -255,11 +423,7 @@
         "location": "Bangalore,India",
         "date": "2024",
         "sessionTitle": "💘Heart to Heart with an XM Cloud Architect💘 (with Liz)",
-        "topics": [
-          "XM Cloud Architecture",
-          "Candid Review",
-          "Collaboration"
-        ],
+        "topics": ["XM Cloud Architecture", "Candid Review", "Collaboration"],
         "description": "Collaborative presentation with Liz Nelson offering a candid review of the XM Cloud journey, sharing wins, losses, and insights from the founding architect's perspective alongside implementation expertise.",
         "videoUrl": "https://www.youtube.com/watch?v=IEbZIOVPzW4&list=PLvwdDTmlDsRwv59ccvK5sodnaLLu9_AfT&index=9"
       },
@@ -269,11 +433,7 @@
         "location": "Dublin, Ireland",
         "date": "April 2024",
         "sessionTitle": "Building for Resiliency",
-        "topics": [
-          "System Architecture",
-          "Scalability",
-          "Performance"
-        ],
+        "topics": ["System Architecture", "Scalability", "Performance"],
         "description": "Explored architectural patterns and best practices for building resilient, scalable CMS systems that can withstand high traffic loads and provide consistent performance under varying conditions.",
         "videoUrl": "https://youtu.be/3zLjcHzGT9E?si=BNfEocwSaqBpd7oj&t=33",
         "sessionizeUrl": "https://sessionize.com/andy-cohen"
@@ -375,11 +535,7 @@
         "location": "Budapest, Hungary",
         "date": "April 2022",
         "sessionTitle": "XM Cloud - Build and Deploy in less than 5 minutes",
-        "topics": [
-          "Historic Demo",
-          "XM Cloud Launch",
-          "Live Deployment"
-        ],
+        "topics": ["Historic Demo", "XM Cloud Launch", "Live Deployment"],
         "description": "Historic live demonstration of Sitecore's next generation product, XM Cloud. The very first public demonstration of XM Cloud Deploy, successfully deploying Sitecore from an empty cloud environment in just over 5 minutes. This session introduced the Sitecore community to what XM Cloud is, what it isn't, and marked the beginning of the SaaS journey for Sitecore.",
         "videoUrl": "https://youtu.be/Sm4X6EG8fCU?si=grZaN16g-2V9sHaF&t=44",
         "documentationUrl": "https://www.flux-digital.com/blog/sugcon-2022-thoughts-takeaways/",

--- a/content/data.json
+++ b/content/data.json
@@ -215,7 +215,7 @@
       ]
     },
     {
-      "title": "Lipstick on a Pig: Why Most Agents Aren't",
+      "title": "Lipstick on a Pig: Why Most 'Agents' Aren't Agents",
       "url": "https://www.linkedin.com/pulse/lipstick-pig-why-most-agents-arent-andy-cohen-grotc/",
       "platform": "LinkedIn",
       "type": "article",
@@ -229,7 +229,7 @@
       "topics": ["AI Agents", "Orchestration", "Safety", "Production Readiness"]
     },
     {
-      "title": "Commits Don't Lie: XM Cloud's Future in Plain Sight",
+      "title": "The Commits Don't Lie: XM Cloud's Future in Plain Sight",
       "url": "https://www.linkedin.com/pulse/commits-dont-lie-xm-clouds-future-plain-sight-andy-cohen-qgnsc/",
       "platform": "LinkedIn",
       "type": "article",

--- a/src/app/articles/page.tsx
+++ b/src/app/articles/page.tsx
@@ -1,0 +1,279 @@
+import { generatePageMetadata } from '@/lib/metadata-generators';
+import { getDisplayName } from '@/lib/data-helpers';
+import data from '@/lib/data';
+import { ThoughtLeadership } from '@/types';
+
+const displayName = getDisplayName(data.contact);
+
+export const metadata = generatePageMetadata(
+  'Articles',
+  `Thought leadership articles by ${data.contact.name} on AI, digital experience platforms, content management, and the future of software architecture.`,
+  data.contact,
+  {
+    other: {
+      'ai:content-type': 'articles,thought-leadership,insights',
+      'ai:topics': 'ai,dxp,cms,software-architecture,digital-transformation',
+      'professional:thought-leadership': 'true',
+    },
+    openGraph: {
+      title: `${displayName}'s Articles - Thought Leadership on AI & DXP`,
+      description: `Thought leadership articles on AI, digital experience platforms, and software architecture by ${data.contact.name}.`,
+    },
+  },
+  '/articles'
+);
+
+export default function Articles() {
+  const thoughtLeadership = data.thoughtLeadership || [];
+
+  return (
+    <>
+      {/* Hero Section */}
+      <section className="section-padding bg-gradient-to-br from-primary-50 via-white to-secondary-50">
+        <div className="container-max">
+          <div className="max-w-4xl mx-auto text-center">
+            <div className="inline-flex items-center gap-2 bg-gradient-to-r from-primary-100 to-secondary-100 px-4 py-2 rounded-full text-sm font-medium mb-6">
+              <span className="w-2 h-2 bg-primary-500 rounded-full"></span>
+              Thought Leadership
+            </div>
+            <h1 className="text-4xl md:text-5xl font-bold text-gray-900 mb-6">
+              Articles & Insights
+            </h1>
+            <p className="text-lg text-gray-600 leading-relaxed">
+              Exploring the intersection of AI, digital experience platforms,
+              and software architecture. Insights from building and scaling
+              enterprise systems in the age of AI.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Articles Section */}
+      <section className="section-padding">
+        <div className="container-max">
+          <div className="max-w-4xl mx-auto">
+            {/* Stats Bar */}
+            <div className="bg-gradient-to-r from-primary-50 to-secondary-50 rounded-lg p-6 mb-12 border border-primary-100">
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
+                <div>
+                  <div className="text-3xl font-bold text-primary-700">
+                    {thoughtLeadership.length}
+                  </div>
+                  <div className="text-sm text-gray-600">Articles</div>
+                </div>
+                <div>
+                  <div className="text-3xl font-bold text-primary-700">
+                    {
+                      thoughtLeadership.filter((a) => a.platform === 'LinkedIn')
+                        .length
+                    }
+                  </div>
+                  <div className="text-sm text-gray-600">LinkedIn</div>
+                </div>
+                <div>
+                  <div className="text-3xl font-bold text-primary-700">
+                    {
+                      thoughtLeadership.filter(
+                        (a) => a.platform === 'CMS Critic'
+                      ).length
+                    }
+                  </div>
+                  <div className="text-sm text-gray-600">CMS Critic</div>
+                </div>
+                <div>
+                  <div className="text-3xl font-bold text-primary-700">
+                    2025
+                  </div>
+                  <div className="text-sm text-gray-600">Latest</div>
+                </div>
+              </div>
+            </div>
+
+            {/* Articles List */}
+            <div className="space-y-8">
+              {thoughtLeadership.map(
+                (article: ThoughtLeadership, index: number) => (
+                  <article
+                    key={index}
+                    className="bg-white rounded-lg border border-gray-200 p-8 shadow-sm hover:shadow-md transition-shadow"
+                  >
+                    {/* Header */}
+                    <div className="mb-6">
+                      <div className="flex items-start justify-between gap-4 mb-3">
+                        <h2 className="text-2xl font-bold text-gray-900 leading-tight">
+                          {article.title}
+                        </h2>
+                        <div
+                          className={`flex-shrink-0 w-12 h-12 rounded-lg flex items-center justify-center text-xl ${
+                            article.platform === 'CMS Critic'
+                              ? 'bg-purple-100 text-purple-700'
+                              : 'bg-blue-100 text-blue-700'
+                          }`}
+                        >
+                          {article.platform === 'CMS Critic' ? '📝' : '💼'}
+                        </div>
+                      </div>
+
+                      {/* Meta */}
+                      <div className="flex flex-wrap items-center gap-2 text-sm text-gray-600">
+                        <span className="font-medium text-primary-600">
+                          {article.platform}
+                        </span>
+                        <span className="text-gray-400">•</span>
+                        <time dateTime={article.date}>{article.date}</time>
+                      </div>
+                    </div>
+
+                    {/* Summary */}
+                    <p className="text-lg text-gray-700 leading-relaxed mb-6">
+                      {article.summary}
+                    </p>
+
+                    {/* Highlights */}
+                    {article.highlights && article.highlights.length > 0 && (
+                      <div className="mb-6">
+                        <h3 className="text-sm font-semibold text-gray-900 uppercase tracking-wide mb-3">
+                          Key Insights
+                        </h3>
+                        <ul className="space-y-2">
+                          {article.highlights.map((highlight, idx) => (
+                            <li key={idx} className="flex items-start gap-3">
+                              <svg
+                                className="w-5 h-5 text-primary-500 mt-0.5 flex-shrink-0"
+                                fill="none"
+                                stroke="currentColor"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  strokeWidth={2}
+                                  d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                                />
+                              </svg>
+                              <span className="text-gray-700 leading-relaxed">
+                                {highlight}
+                              </span>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+
+                    {/* Topics & Read Link */}
+                    <div className="flex flex-wrap items-center justify-between gap-4 pt-4 border-t border-gray-100">
+                      {/* Topics */}
+                      {article.topics && article.topics.length > 0 && (
+                        <div className="flex flex-wrap gap-2">
+                          {article.topics.map((topic, idx) => (
+                            <span
+                              key={idx}
+                              className="px-3 py-1 bg-gray-100 text-gray-700 text-xs font-medium rounded-full"
+                            >
+                              {topic}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+
+                      {/* Read Link */}
+                      <a
+                        href={article.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-2 px-4 py-2 bg-primary-600 text-white text-sm font-medium rounded-lg hover:bg-primary-700 transition-colors group flex-shrink-0"
+                      >
+                        Read Article
+                        <svg
+                          className="w-4 h-4 transition-transform group-hover:translate-x-1"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M17 8l4 4m0 0l-4 4m4-4H3"
+                          />
+                        </svg>
+                      </a>
+                    </div>
+                  </article>
+                )
+              )}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Topics Section */}
+      <section className="section-padding bg-gray-50">
+        <div className="container-max">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-2xl font-bold text-gray-900 mb-6 text-center">
+              Topics Covered
+            </h2>
+            <div className="flex flex-wrap justify-center gap-3">
+              {[
+                'AI & Agents',
+                'Digital Experience Platforms',
+                'Content Management',
+                'Software Architecture',
+                'XM Cloud',
+                'Developer Experience',
+                'Product Management',
+                'Digital Transformation',
+                'Platform Engineering',
+                'Enterprise Systems',
+              ].map((topic, index) => (
+                <span
+                  key={index}
+                  className="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm font-medium text-gray-700 hover:border-primary-300 hover:bg-primary-50 transition-colors"
+                >
+                  {topic}
+                </span>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* CTA Section */}
+      <section className="section-padding">
+        <div className="container-max">
+          <div className="max-w-4xl mx-auto text-center">
+            <h2 className="text-3xl md:text-4xl font-bold mb-6">
+              Let&apos;s Connect
+            </h2>
+            <p className="text-lg text-gray-600 mb-8">
+              Interested in discussing AI, digital experience platforms, or
+              software architecture? I&apos;m always up for conversations about
+              the future of technology.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <a href="/contact" className="btn-primary">
+                Get in Touch
+              </a>
+              <a
+                href="https://www.linkedin.com/in/iamandycohen"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="btn-secondary inline-flex items-center gap-2"
+              >
+                <svg
+                  className="w-4 h-4"
+                  fill="currentColor"
+                  viewBox="0 0 20 20"
+                >
+                  <path d="M16.338 16.338H13.67V12.16c0-.995-.017-2.277-1.387-2.277-1.39 0-1.601 1.086-1.601 2.207v4.248H8.014v-8.59h2.559v1.174h.037c.356-.675 1.227-1.387 2.526-1.387 2.703 0 3.203 1.778 3.203 4.092v4.711zM5.005 6.575a1.548 1.548 0 11-.003-3.096 1.548 1.548 0 01.003 3.096zm-1.337 9.763H6.34v-8.59H3.667v8.59zM17.668 1H2.328C1.595 1 1 1.581 1 2.298v15.403C1 18.418 1.595 19 2.328 19h15.34c.734 0 1.332-.582 1.332-1.299V2.298C19 1.581 18.402 1 17.668 1z" />
+                </svg>
+                Follow on LinkedIn
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/src/app/community/_components/CommunityTabs.tsx
+++ b/src/app/community/_components/CommunityTabs.tsx
@@ -1,6 +1,7 @@
-"use client";
+'use client';
 
-import { useState } from "react";
+import { useState, useEffect, Suspense } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 interface Tab {
   id: string;
@@ -13,8 +14,31 @@ interface CommunityTabsProps {
   tabs: Tab[];
 }
 
-export default function CommunityTabs({ tabs }: CommunityTabsProps) {
-  const [activeTab, setActiveTab] = useState(tabs[0]?.id || "");
+function CommunityTabsContent({ tabs }: CommunityTabsProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const tabFromUrl = searchParams.get('tab');
+
+  // Initialize with URL tab or first tab
+  const initialTab =
+    tabFromUrl && tabs.some((t) => t.id === tabFromUrl)
+      ? tabFromUrl
+      : tabs[0]?.id || '';
+
+  const [activeTab, setActiveTab] = useState(initialTab);
+
+  // Update URL when tab changes
+  const handleTabChange = (tabId: string) => {
+    setActiveTab(tabId);
+    router.push(`/community?tab=${tabId}`, { scroll: false });
+  };
+
+  // Sync state with URL changes (e.g., browser back/forward)
+  useEffect(() => {
+    if (tabFromUrl && tabs.some((t) => t.id === tabFromUrl)) {
+      setActiveTab(tabFromUrl);
+    }
+  }, [tabFromUrl, tabs]);
 
   return (
     <div className="bg-white rounded-lg shadow-sm border border-gray-200">
@@ -26,15 +50,15 @@ export default function CommunityTabs({ tabs }: CommunityTabsProps) {
             return (
               <button
                 key={tab.id}
-                onClick={() => setActiveTab(tab.id)}
+                onClick={() => handleTabChange(tab.id)}
                 className={`px-6 py-4 text-sm font-medium border-b-2 focus:outline-none transition-all duration-200 ${
                   isActive
-                    ? "text-primary-600 bg-gray-50 border-primary-600"
-                    : "text-gray-500 hover:text-gray-700 hover:bg-gray-50 border-transparent hover:border-gray-300 focus:text-primary-600 focus:border-primary-600"
+                    ? 'text-primary-600 bg-gray-50 border-primary-600'
+                    : 'text-gray-500 hover:text-gray-700 hover:bg-gray-50 border-transparent hover:border-gray-300 focus:text-primary-600 focus:border-primary-600'
                 }`}
                 role="tab"
                 aria-controls={tab.id}
-                aria-selected={isActive ? "true" : "false"}
+                aria-selected={isActive ? 'true' : 'false'}
               >
                 {tab.icon} {tab.label}
               </button>
@@ -48,5 +72,25 @@ export default function CommunityTabs({ tabs }: CommunityTabsProps) {
         {tabs.find((tab) => tab.id === activeTab)?.content}
       </div>
     </div>
+  );
+}
+
+export default function CommunityTabs({ tabs }: CommunityTabsProps) {
+  return (
+    <Suspense
+      fallback={
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-8">
+          <div className="animate-pulse">
+            <div className="h-8 bg-gray-200 rounded w-1/4 mb-4"></div>
+            <div className="space-y-3">
+              <div className="h-4 bg-gray-200 rounded"></div>
+              <div className="h-4 bg-gray-200 rounded w-5/6"></div>
+            </div>
+          </div>
+        </div>
+      }
+    >
+      <CommunityTabsContent tabs={tabs} />
+    </Suspense>
   );
 }

--- a/src/app/sitemap.xml/route.ts
+++ b/src/app/sitemap.xml/route.ts
@@ -1,25 +1,26 @@
-import { NextRequest, NextResponse } from "next/server";
-import { getConfiguredSiteUrl } from "@/lib/url-helpers";
+import { NextRequest, NextResponse } from 'next/server';
+import { getConfiguredSiteUrl } from '@/lib/url-helpers';
 
 interface SitemapEntry {
   path: string;
   priority: number;
-  changefreq: "daily" | "weekly" | "monthly" | "yearly";
+  changefreq: 'daily' | 'weekly' | 'monthly' | 'yearly';
 }
 
 export async function GET(_request: NextRequest) {
   const baseUrl = getConfiguredSiteUrl();
-  const lastmod = new Date().toISOString().split("T")[0];
+  const lastmod = new Date().toISOString().split('T')[0];
 
   // Define all URLs with their priorities and change frequencies
   const urls: SitemapEntry[] = [
-    { path: "/", priority: 1.0, changefreq: "daily" },
-    { path: "/resume", priority: 0.8, changefreq: "daily" },
-    { path: "/projects", priority: 0.8, changefreq: "daily" },
-    { path: "/contact", priority: 0.8, changefreq: "daily" },
-    { path: "/community", priority: 0.8, changefreq: "daily" },
-    { path: "/ai-chat", priority: 0.8, changefreq: "daily" },
-    { path: "/ai-tools", priority: 0.7, changefreq: "daily" },
+    { path: '/', priority: 1.0, changefreq: 'daily' },
+    { path: '/resume', priority: 0.8, changefreq: 'daily' },
+    { path: '/projects', priority: 0.8, changefreq: 'daily' },
+    { path: '/articles', priority: 0.9, changefreq: 'weekly' },
+    { path: '/contact', priority: 0.8, changefreq: 'daily' },
+    { path: '/community', priority: 0.8, changefreq: 'daily' },
+    { path: '/ai-chat', priority: 0.8, changefreq: 'daily' },
+    { path: '/ai-tools', priority: 0.7, changefreq: 'daily' },
   ];
 
   // Generate sitemap URLs
@@ -28,7 +29,7 @@ export async function GET(_request: NextRequest) {
       ({ path, priority, changefreq }) =>
         `  <url><loc>${baseUrl}${path}</loc><lastmod>${lastmod}</lastmod><changefreq>${changefreq}</changefreq><priority>${priority}</priority></url>`
     )
-    .join("\n");
+    .join('\n');
 
   const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
@@ -38,8 +39,8 @@ ${urlEntries}
   return new NextResponse(sitemap, {
     status: 200,
     headers: {
-      "Content-Type": "text/xml",
-      "Cache-Control": "public, s-maxage=86400, stale-while-revalidate",
+      'Content-Type': 'text/xml',
+      'Cache-Control': 'public, s-maxage=86400, stale-while-revalidate',
     },
   });
 }

--- a/src/components/ui/Navigation.tsx
+++ b/src/components/ui/Navigation.tsx
@@ -1,10 +1,10 @@
-"use client";
+'use client';
 
-import Link from "next/link";
-import { useState, memo } from "react";
-import { usePathname } from "next/navigation";
-import { getDisplayName } from "@/lib/data-helpers";
-import data from "@/lib/data";
+import Link from 'next/link';
+import { useState, memo } from 'react';
+import { usePathname } from 'next/navigation';
+import { getDisplayName } from '@/lib/data-helpers';
+import data from '@/lib/data';
 
 const displayName = getDisplayName(data.contact);
 
@@ -27,29 +27,31 @@ function Navigation() {
 
   // Map pathnames to their source files
   const getGitHubUrl = (currentPath: string) => {
-    const baseUrl = "https://github.com/iamandycohen/me/blob/main/src/app";
+    const baseUrl = 'https://github.com/iamandycohen/me/blob/main/src/app';
     const pathMap: { [key: string]: string } = {
-      "/": "page.tsx",
-      "/resume": "resume/page.tsx",
-      "/projects": "projects/page.tsx",
-      "/community": "community/page.tsx",
-      "/contact": "contact/page.tsx",
-      "/ai-chat": "ai-chat/page.tsx",
-      "/ai-tools": "ai-tools/page.tsx",
+      '/': 'page.tsx',
+      '/resume': 'resume/page.tsx',
+      '/projects': 'projects/page.tsx',
+      '/articles': 'articles/page.tsx',
+      '/community': 'community/page.tsx',
+      '/contact': 'contact/page.tsx',
+      '/ai-chat': 'ai-chat/page.tsx',
+      '/ai-tools': 'ai-tools/page.tsx',
     };
 
-    const filePath = pathMap[currentPath] || "page.tsx";
+    const filePath = pathMap[currentPath] || 'page.tsx';
     return `${baseUrl}/${filePath}`;
   };
 
   const navigation = [
-    { name: "About", href: "/" },
-    { name: "Resume", href: "/resume" },
-    { name: "Projects", href: "/projects" },
-    { name: "Community", href: "/community" },
-    { name: "Contact", href: "/contact" },
-    { name: "AI Chat", href: "/ai-chat" },
-    { name: "AI Tools Demo", href: "/ai-tools" },
+    { name: 'About', href: '/' },
+    { name: 'Resume', href: '/resume' },
+    { name: 'Projects', href: '/projects' },
+    { name: 'Articles', href: '/articles' },
+    { name: 'Community', href: '/community' },
+    { name: 'Contact', href: '/contact' },
+    { name: 'AI Chat', href: '/ai-chat' },
+    { name: 'AI Tools Demo', href: '/ai-tools' },
   ];
 
   const toggleMobileMenu = () => {
@@ -96,17 +98,17 @@ function Navigation() {
           >
             <div
               className={`w-6 h-0.5 bg-gray-600 transition-all duration-300 ${
-                isMobileMenuOpen ? "rotate-45 translate-y-2" : ""
+                isMobileMenuOpen ? 'rotate-45 translate-y-2' : ''
               }`}
             ></div>
             <div
               className={`w-6 h-0.5 bg-gray-600 transition-all duration-300 ${
-                isMobileMenuOpen ? "opacity-0" : ""
+                isMobileMenuOpen ? 'opacity-0' : ''
               }`}
             ></div>
             <div
               className={`w-6 h-0.5 bg-gray-600 transition-all duration-300 ${
-                isMobileMenuOpen ? "-rotate-45 -translate-y-2" : ""
+                isMobileMenuOpen ? '-rotate-45 -translate-y-2' : ''
               }`}
             ></div>
           </button>
@@ -116,8 +118,8 @@ function Navigation() {
         <div
           className={`md:hidden transition-all duration-300 ease-in-out ${
             isMobileMenuOpen
-              ? "max-h-96 opacity-100"
-              : "max-h-0 opacity-0 overflow-hidden"
+              ? 'max-h-96 opacity-100'
+              : 'max-h-0 opacity-0 overflow-hidden'
           }`}
         >
           <div className="py-4 border-t border-gray-200">

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1,7 +1,15 @@
 // Centralized data import to avoid inconsistent relative paths throughout the app
-import data from "../../content/data.json";
+import data from '../../content/data.json';
 
 export default data;
 
 // Named exports for common data sections for convenience
-export const { contact, bio, professional, resume, projects, community } = data;
+export const {
+  contact,
+  bio,
+  professional,
+  resume,
+  projects,
+  community,
+  thoughtLeadership,
+} = data;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -131,6 +131,18 @@ export interface ProjectsResponse {
   projects: Project[];
 }
 
+// Thought Leadership entry
+export interface ThoughtLeadership {
+  title: string;
+  url: string;
+  platform: string;
+  type: string;
+  date: string;
+  summary: string;
+  highlights: string[];
+  topics: string[];
+}
+
 // API Input types
 export interface BioInput {
   format?: 'short' | 'full';
@@ -142,4 +154,4 @@ export interface ResumeInput {
 
 export interface ProjectsInput {
   limit?: number;
-} 
+}


### PR DESCRIPTION
- Create dedicated /articles page with rich article display
  - Show article summaries, key insights, and topic tags
  - Display 11 thought leadership articles from LinkedIn and CMS Critic
- Update data.json with comprehensive article metadata
  - Add summary, highlights, and topics for each article
  - Fix Altudo employment period (Sep 2024 - Oct 2025)
  - Update bio to reflect new focus on AI, products, platforms
- Add Articles link to navigation between Projects and Community
- Update sitemap to include /articles with high priority
- Update TypeScript types for new article structure
- Fix ESLint errors with proper HTML entity encoding

All tests pass (227/227) and build is successful.