### PR TITLE
fix(resume): correct intro copy

### DIFF
--- a/src/app/resume/page.tsx
+++ b/src/app/resume/page.tsx
@@ -26,9 +26,10 @@ export default function Resume() {
             </span>
           </h1>
           <p className="text-lg text-ink/70 leading-relaxed max-w-2xl">
-            From applicant tracking systems written as a kid, to enterprise CMS
-            platforms serving millions — the throughline is engineering
-            craftsmanship and systems that scale.
+            From learning to code as a kid, to shipping applicant tracking and
+            time-management systems, to enterprise CMS platforms serving
+            millions — the throughline is engineering craftsmanship and systems
+            that scale.
           </p>
         </div>
 


### PR DESCRIPTION
Replaces the inaccurate line on /resume.

Before: "From applicant tracking systems written as a kid, to enterprise CMS platforms serving millions…"
After:  "From learning to code as a kid, to shipping applicant tracking and time-management systems, to enterprise CMS platforms serving millions…"

Reflects the actual timeline: learned to code as a kid; ATS/time-management work came later (matches /resume entries and the bio in content/data.json).