### PR TITLE
chore: copy polish (home, articles, contact)

### DIFF
--- a/src/app/articles/page.tsx
+++ b/src/app/articles/page.tsx
@@ -30,8 +30,8 @@ export default function Articles() {
           <div className="max-w-3xl">
             <p className="eyebrow mb-6">Writing</p>
             <h1 className="text-balance mb-6">
-              Articles{' '}
-              <span className="italic text-ink/60">&amp; insights.</span>
+              Writing{' '}
+              <span className="italic text-ink/60">&amp; arguments.</span>
             </h1>
             <p className="text-lg text-ink/70 leading-relaxed max-w-2xl">
               Exploring the intersection of AI, digital experience platforms,
@@ -135,21 +135,16 @@ export default function Articles() {
               {[
                 'AI & Agents',
                 'Digital Experience Platforms',
-                'Content Management',
-                'Software Architecture',
-                'XM Cloud',
-                'Developer Experience',
-                'Product Strategy',
-                'Digital Transformation',
                 'Platform Engineering',
-                'Enterprise Systems',
-              ].map((topic, index) => (
+                'Software Architecture',
+                'Product Strategy',
+              ].map((topic, index, arr) => (
                 <li
                   key={index}
                   className="font-serif italic text-lg md:text-xl"
                 >
                   {topic}
-                  {index < 9 && (
+                  {index < arr.length - 1 && (
                     <span className="text-accent/60 ml-4" aria-hidden="true">
                       ·
                     </span>

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -29,7 +29,7 @@ export default function Contact() {
           <p className="text-lg text-ink/70 leading-relaxed max-w-2xl">
             CMS platform challenges, AI integration, agentic workflows,
             architecture review — or just a conversation about where things are
-            headed. I&apos;m up for it.
+            headed. Let&apos;s compare notes.
           </p>
         </div>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -164,7 +164,7 @@ export default function Home() {
           <div className="max-w-3xl">
             <p className="eyebrow mb-4">Connect</p>
             <h2 className="text-balance mb-8">
-              I have a bit of free time.{' '}
+              Still curious. Still building.{' '}
               <span className="italic text-ink/60">Reach out.</span>
             </h2>
             <div className="flex flex-wrap items-center gap-x-8 gap-y-4 text-lg">


### PR DESCRIPTION
Small prose tweaks suggested during a copy audit. No structural changes; no data changes.

### Home
- Connect heading: `I have a bit of free time. Reach out.` → `Still curious. Still building. Reach out.`
  (the throwaway tone undersold the rest of the page)

### Articles
- H1: `Articles & insights.` → `Writing & arguments.`
  ("insights" is the most overused word in tech marketing)
- Topics list: trimmed from 10 overlapping to 5 distinct
  - kept: AI & Agents · Digital Experience Platforms · Platform Engineering · Software Architecture · Product Strategy
  - dropped redundant: Content Management, XM Cloud, Developer Experience, Digital Transformation, Enterprise Systems

### Contact
- Subhead closer: `I'm up for it.` → `Let's compare notes.`

### Validation
- `npm run type-check` ✓
- `npm run lint` ✓
- `npm run test:ci` → 79/79 ✓